### PR TITLE
5 update pandas deprecation warnings

### DIFF
--- a/annotating_nmd/__init__.py
+++ b/annotating_nmd/__init__.py
@@ -180,7 +180,7 @@ def make_cds_size_df(bed_df):
     if 'cds_size' not in bed_df.columns:
         bed_df = preprocess_bed(bed_df)
 
-    cds_sizes = bed_df.groupby('transcript_name').cds_size.apply(sum).reset_index().rename(columns={0: 'cds_size'})
+    cds_sizes = bed_df.groupby('transcript_name').cds_size.sum().reset_index().rename(columns={0: 'cds_size'})
     nmd_sizes = bed_df.groupby('transcript_name').apply(
         get_nmd_escape_size, include_groups=False
     ).reset_index().rename(columns={0: 'nmd_escape_size'})

--- a/annotating_nmd/__init__.py
+++ b/annotating_nmd/__init__.py
@@ -161,7 +161,7 @@ def make_boundaries_df(bed_df):
     if 'transcript_name' not in bed_df.columns:
         bed_df = preprocess_bed(bed_df)
 
-    boundaries_df = bed_df.groupby('transcript_name').apply(get_nmd_escape_boundaries)
+    boundaries_df = bed_df.groupby('transcript_name').apply(get_nmd_escape_boundaries, include_groups=False)
     return boundaries_df
 
 
@@ -181,7 +181,9 @@ def make_cds_size_df(bed_df):
         bed_df = preprocess_bed(bed_df)
 
     cds_sizes = bed_df.groupby('transcript_name').cds_size.apply(sum).reset_index().rename(columns={0: 'cds_size'})
-    nmd_sizes = bed_df.groupby('transcript_name').apply(get_nmd_escape_size).reset_index().rename(columns={0: 'nmd_escape_size'})
+    nmd_sizes = bed_df.groupby('transcript_name').apply(
+        get_nmd_escape_size, include_groups=False
+    ).reset_index().rename(columns={0: 'nmd_escape_size'})
 
     # combine cds size and nmd(-) size into 1 dataframe
     sizes = cds_sizes.merge(nmd_sizes, on='transcript_name', how='outer')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools", "wheel"]
 name = 'nmd-escape'
 version = '0.1'
 dependencies = [
-        'pandas',
+        'pandas >= 2.2',
         'numpy',
     ]
 requires-python = '>= 3.9'

--- a/tests/test_annotating_nmd.py
+++ b/tests/test_annotating_nmd.py
@@ -142,7 +142,7 @@ class TestNMD(unittest.TestCase):
         # throw warnings
         with self.assertWarns(Warning) as context:
             get_upstream_frameshift(test_df.iloc[-3:].copy(), sizes_df)
-            self.assertTrue(issubclass(context.warnings[0].category, HGVSpPatternWarning))
+            self.assertTrue(any([issubclass(warning.category, HGVSpPatternWarning) for warning in context.warnings]))
 
 
 if __name__ == '__main__':

--- a/tests/test_annotating_nmd.py
+++ b/tests/test_annotating_nmd.py
@@ -85,7 +85,7 @@ class TestNMD(unittest.TestCase):
 
         # test on all transcripts
         cds_df = preprocess_bed(TestNMD.cds_bed.copy())
-        nmd_df = cds_df.groupby('transcript_name').apply(get_nmd_escape_boundaries)
+        nmd_df = cds_df.groupby('transcript_name').apply(get_nmd_escape_boundaries, include_groups=False)
         self.assertEqual(len(nmd_df), 4)
 
         # test convenience wrapper


### PR DESCRIPTION
Closes #5 

* Add `include_groups=False` to pandas groupby calls to avoid DeprecationWarning
* Use pandas `sum` function instead of `apply(sum)` which uses numpy to avoid FutureWarning
* Update unittests to be agnostic to index of warnings